### PR TITLE
Update js/jquery.coda-slider-3.0.js

### DIFF
--- a/js/jquery.coda-slider-3.0.js
+++ b/js/jquery.coda-slider-3.0.js
@@ -74,7 +74,13 @@ if ( typeof Object.create !== 'function' ) {
 			if (self.options.dynamicArrows) { self.addArrows(); }
 
 			// Create a container width to allow for a smooth float right.
-			self.totalSliderWidth = $(self.sliderId).outerWidth(true) + $($(self.sliderId).parent()).children('[class^=coda-nav-left]').outerWidth(true) + $($(self.sliderId).parent()).children('[class^=coda-nav-right]').outerWidth(true);
+			self.totalSliderWidth = $(self.sliderId).outerWidth(true);
+			if($($(self.sliderId).parent()).children('[class^=coda-nav-left]').css('position') != 'absolute') {
+				self.totalSliderWidth += $($(self.sliderId).parent()).children('[class^=coda-nav-left]').outerWidth(true);
+			}
+			if($($(self.sliderId).parent()).children('[class^=coda-nav-right]').css('position') != 'absolute') {
+				self.totalSliderWidth += $($(self.sliderId).parent()).children('[class^=coda-nav-right]').outerWidth(true);
+			}
 			$($(self.sliderId).parent()).css('width', self.totalSliderWidth);
 
 			// Align navigation tabs


### PR DESCRIPTION
I mostly want to add the arrows on the slider panels and not want them near the sliders (with floats or so). With this change the positioning of the coda-nav-left and right is checked. When you positionate them absolute they will not need to increase the width of the slider-wrapper.
