### PR TITLE
Bower conflicts with other plugins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "ignore":[],
   "license": "MIT",
   "dependencies": {
-    "jQuery": ">=1.7",
+    "jquery": ">=1.7",
     "jquery.easing": "~1.3.1"
   }
 }


### PR DESCRIPTION
My project went down because of the name. In codaslider's bower.json there is "jQuerry" whereas it should be "jquery"
